### PR TITLE
fixes #11 Typo in assertEquals

### DIFF
--- a/tests/unit/e_parseTest.php
+++ b/tests/unit/e_parseTest.php
@@ -99,7 +99,7 @@ TMP;
 
 			$actual = $this->tp->toForm($db);
 
-			$this->assertEquals($db,$actual);
+			$this->assertEquals($orig, $actual);
 			
 		}
 /*


### PR DESCRIPTION
removed the typo in `e_parseTest::testToForm()`
The test now fails, because the `e_parse_class::toForm()` doesn't convert `&#039;` back to `'`.
I'll create a PR for this issue.