### PR TITLE
added missing constant ADMINPERMS to succeed the getperms check

### DIFF
--- a/tests/unit/lancheckTest.php
+++ b/tests/unit/lancheckTest.php
@@ -15,6 +15,8 @@
 
 		protected function _before()
 		{
+			// fix for getperms("L") check in lancheck.php
+			define('ADMINPERMS', 'L');
 
 			require_once(e_ADMIN."lancheck.php");
 


### PR DESCRIPTION
added missing constant ADMINPERMS to succeed the getperms check at the beginning of the lancheck.php file.